### PR TITLE
UXP-458: Upgrade to PLF 4.3

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-parent</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo-clouddrive-config</artifactId>

--- a/connectors/box/pom.xml
+++ b/connectors/box/pom.xml
@@ -25,7 +25,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-connectors</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-box</artifactId>
   <packaging>pom</packaging>

--- a/connectors/box/services/pom.xml
+++ b/connectors/box/services/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-box</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-box-services</artifactId>
   <packaging>jar</packaging>

--- a/connectors/box/webapp/pom.xml
+++ b/connectors/box/webapp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-box</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-box-webapp</artifactId>
   <packaging>war</packaging>

--- a/connectors/cmis/pom.xml
+++ b/connectors/cmis/pom.xml
@@ -25,7 +25,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-connectors</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-cmis</artifactId>
   <packaging>pom</packaging>

--- a/connectors/cmis/services/pom.xml
+++ b/connectors/cmis/services/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-cmis</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-cmis-services</artifactId>
   <packaging>jar</packaging>

--- a/connectors/cmis/webapp/pom.xml
+++ b/connectors/cmis/webapp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-cmis</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-cmis-webapp</artifactId>
   <packaging>war</packaging>

--- a/connectors/dropbox/pom.xml
+++ b/connectors/dropbox/pom.xml
@@ -25,7 +25,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-connectors</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
 
   <artifactId>exo-clouddrive-dropbox</artifactId>

--- a/connectors/dropbox/services/pom.xml
+++ b/connectors/dropbox/services/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-dropbox</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-dropbox-services</artifactId>
   <packaging>jar</packaging>

--- a/connectors/dropbox/webapp/pom.xml
+++ b/connectors/dropbox/webapp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-dropbox</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-dropbox-webapp</artifactId>
   <packaging>war</packaging>

--- a/connectors/gdrive/pom.xml
+++ b/connectors/gdrive/pom.xml
@@ -25,7 +25,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-connectors</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-gdrive</artifactId>
   <packaging>pom</packaging>

--- a/connectors/gdrive/services/pom.xml
+++ b/connectors/gdrive/services/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-gdrive</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-gdrive-services</artifactId>
   <packaging>jar</packaging>

--- a/connectors/gdrive/webapp/pom.xml
+++ b/connectors/gdrive/webapp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-gdrive</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-gdrive-webapp</artifactId>
   <packaging>war</packaging>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-parent</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-connectors</artifactId>
   <packaging>pom</packaging>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-parent</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-packaging</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <version>5</version>
   </parent>
   <artifactId>exo-clouddrive-parent</artifactId>
-  <version>1.3.x-SNAPSHOT</version>
+  <version>1.3.x-plf43-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Cloud Drive :: Parent</name>
   <description>eXo Cloud Drive extension project reactor</description>
@@ -45,7 +45,7 @@
     <maven.compiler.target>1.7</maven.compiler.target>
 
     <!-- eXo Modules -->
-    <org.exoplatform.platform.version>4.2.0</org.exoplatform.platform.version>
+    <org.exoplatform.platform.version>4.3.0-M3</org.exoplatform.platform.version>
 
     <!-- Google API -->
     <com.google.api.client.version>1.20.0</com.google.api.client.version>
@@ -63,7 +63,7 @@
     <org.apache.chemistry.opencmis.version>0.13.0</org.apache.chemistry.opencmis.version>
 
     <!-- for tests -->
-    <org.exoplatform.jcr-services.version>1.15.13-GA</org.exoplatform.jcr-services.version>
+    <org.exoplatform.jcr-services.version>1.16.1-GA</org.exoplatform.jcr-services.version>
     <test.groovy.version>2.0.8</test.groovy.version>
     <!-- spock.version>1.0-groovy-2.0-SNAPSHOT</spock.version -->
     <spock.version>0.7-groovy-2.0</spock.version>

--- a/services/core/pom.xml
+++ b/services/core/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-services</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-services-core</artifactId>
   <packaging>jar</packaging>

--- a/services/core/src/test/java/org/exoplatform/clouddrive/jcr/TestJCRRemoveObservation.java
+++ b/services/core/src/test/java/org/exoplatform/clouddrive/jcr/TestJCRRemoveObservation.java
@@ -121,7 +121,6 @@ public class TestJCRRemoveObservation extends TestCase {
    * @throws RepositoryException
    */
   public void testListenerSelfRemoval() throws Exception {
-
     // dummy listener class
     class DummyListener implements EventListener {
       @Override

--- a/services/core/src/test/resources/conf/configuration.properties
+++ b/services/core/src/test/resources/conf/configuration.properties
@@ -228,11 +228,12 @@ gatein.jcr.datasource.dialect=auto
 gatein.jcr.sessionregistry.sessionmaxage=300
 
 # JCR cache configuration
-gatein.jcr.cache.config=file:${gatein.conf.dir}/jcr/jbosscache/${gatein.jcr.config.type}/cache-config.xml
+gatein.jcr.cache.config=file:${gatein.conf.dir}/jcr/jbosscache/${gatein.jcr.config.type}/infinispan-cache-config.xml
 gatein.jcr.cache.expiration.time=15m
 
 # JCR Locks configuration
-gatein.jcr.lock.cache.config=file:${gatein.conf.dir}/jcr/jbosscache/${gatein.jcr.config.type}/lock-config.xml
+#gatein.jcr.lock.cache.config=file:${gatein.conf.dir}/jcr/jbosscache/${gatein.jcr.config.type}/lock-config.xml
+gatein.jcr.lock.cache.config=file:${gatein.conf.dir}/jcr/jbosscache/${gatein.jcr.config.type}/jcr-infinispan-lock-config.xml
 
 # JCR Index configuration
 gatein.jcr.index.cache.config=file:${gatein.conf.dir}/jcr/jbosscache/${gatein.jcr.config.type}/indexer-config.xml

--- a/services/core/src/test/resources/conf/jcr/jbosscache/cluster/infinispan-cache-config.xml
+++ b/services/core/src/test/resources/conf/jcr/jbosscache/cluster/infinispan-cache-config.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2003-2013 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 3 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<infinispan
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:5.2 http://www.infinispan.org/schemas/infinispan-config-5.2.xsd"
+      xmlns="urn:infinispan:config:5.2">
+
+   <global>
+      <evictionScheduledExecutor factory="org.infinispan.executors.DefaultScheduledExecutorFactory">
+         <properties>
+            <property name="threadNamePrefix" value="EvictionThread"/>
+         </properties>
+      </evictionScheduledExecutor>
+
+      <globalJmxStatistics jmxDomain="platform.insp.cache.template" enabled="true" allowDuplicateDomains="true"/>
+
+      <transport transportClass="org.infinispan.remoting.transport.jgroups.JGroupsTransport" clusterName="${infinispan-cluster-name}" distributedSyncTimeout="20000">
+         <properties>
+            <property name="configurationFile" value="${gatein.jcr.jgroups.config}"/>
+         </properties>
+      </transport>
+   </global>
+
+   <default>
+      <clustering mode="replication">
+         <stateTransfer timeout="20000" fetchInMemoryState="false" />
+         <sync replTimeout="20000"/>
+      </clustering>
+
+      <locking isolationLevel="READ_COMMITTED" lockAcquisitionTimeout="20000" writeSkewCheck="false" concurrencyLevel="500" useLockStriping="false"/>
+      <transaction transactionManagerLookupClass="org.exoplatform.services.transaction.infinispan.JBossStandaloneJTAManagerLookup" syncRollbackPhase="true" syncCommitPhase="true" transactionMode="TRANSACTIONAL"/>
+      <jmxStatistics enabled="true"/>
+      <eviction strategy="LIRS" threadPolicy="DEFAULT" maxEntries="1000000"/>
+      <expiration wakeUpInterval="5000"/>
+   </default>
+</infinispan>

--- a/services/core/src/test/resources/conf/jcr/jbosscache/cluster/jcr-infinispan-lock-config.xml
+++ b/services/core/src/test/resources/conf/jcr/jbosscache/cluster/jcr-infinispan-lock-config.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2003-2013 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 3 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<infinispan
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:5.2 http://www.infinispan.org/schemas/infinispan-config-5.2.xsd"
+      xmlns="urn:infinispan:config:5.2">
+
+   <global>
+      <evictionScheduledExecutor factory="org.infinispan.executors.DefaultScheduledExecutorFactory">
+         <properties>
+            <property name="threadNamePrefix" value="EvictionThread"/>
+         </properties>
+      </evictionScheduledExecutor>
+
+      <globalJmxStatistics jmxDomain="platform.insp.cache.lock" enabled="true" allowDuplicateDomains="true"/>
+
+      <transport transportClass="org.infinispan.remoting.transport.jgroups.JGroupsTransport" clusterName="${infinispan-cluster-name}" distributedSyncTimeout="20000">
+         <properties>
+            <property name="configurationFile" value="${gatein.jcr.jgroups.config}"/>
+         </properties>
+      </transport>
+   </global>
+
+   <default>
+      <clustering mode="replication">
+         <stateTransfer timeout="20000" fetchInMemoryState="false" />
+         <sync replTimeout="20000"/>
+      </clustering>
+
+      <locking isolationLevel="READ_COMMITTED" lockAcquisitionTimeout="20000" writeSkewCheck="false" concurrencyLevel="500" useLockStriping="false"/>
+      <transaction transactionManagerLookupClass="org.exoplatform.services.transaction.infinispan.JBossStandaloneJTAManagerLookup" syncRollbackPhase="true" syncCommitPhase="true" transactionMode="TRANSACTIONAL"/>
+      <jmxStatistics enabled="true"/>
+      <eviction strategy="NONE"/>
+       <loaders passivation="false" shared="true" preload="true">
+           <loader class="org.exoplatform.services.jcr.infinispan.JdbcStringBasedCacheStore" fetchPersistentState="true" ignoreModifications="false" purgeOnStartup="false">
+               <properties>
+                   <property name="stringsTableNamePrefix" value="${infinispan-cl-cache.jdbc.table.name}"/>
+                   <property name="idColumnName" value="${infinispan-cl-cache.jdbc.id.column}"/>
+                   <property name="dataColumnName" value="${infinispan-cl-cache.jdbc.data.column}"/>
+                   <property name="timestampColumnName" value="${infinispan-cl-cache.jdbc.timestamp.column}"/>
+                   <property name="idColumnType" value="${infinispan-cl-cache.jdbc.id.type}"/>
+                   <property name="dataColumnType" value="${infinispan-cl-cache.jdbc.data.type}"/>
+                   <property name="timestampColumnType" value="${infinispan-cl-cache.jdbc.timestamp.type}"/>
+                   <property name="dropTableOnExit" value="${infinispan-cl-cache.jdbc.table.drop}"/>
+                   <property name="createTableOnStart" value="${infinispan-cl-cache.jdbc.table.create}"/>
+                   <property name="connectionFactoryClass" value="${infinispan-cl-cache.jdbc.connectionFactory}"/>
+                   <property name="datasourceJndiLocation" value="${infinispan-cl-cache.jdbc.datasource}"/>
+               </properties>
+               <async enabled="false"/>
+           </loader>
+       </loaders>
+   </default>
+
+</infinispan>

--- a/services/core/src/test/resources/conf/jcr/jbosscache/local/infinispan-cache-config.xml
+++ b/services/core/src/test/resources/conf/jcr/jbosscache/local/infinispan-cache-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2003-2013 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 3 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<infinispan
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:5.2 http://www.infinispan.org/schemas/infinispan-config-5.2.xsd"
+      xmlns="urn:infinispan:config:5.2">
+
+   <global>
+      <evictionScheduledExecutor factory="org.infinispan.executors.DefaultScheduledExecutorFactory">
+         <properties>
+            <property name="threadNamePrefix" value="EvictionThread"/>
+         </properties>
+      </evictionScheduledExecutor>
+
+      <globalJmxStatistics jmxDomain="platform.insp.cache.jcr" enabled="true" allowDuplicateDomains="true"/>
+   </global>
+
+   <default>
+      <locking isolationLevel="READ_COMMITTED" lockAcquisitionTimeout="20000" writeSkewCheck="false" concurrencyLevel="500" useLockStriping="false"/>
+      <transaction transactionManagerLookupClass="org.exoplatform.services.transaction.infinispan.JBossStandaloneJTAManagerLookup" syncRollbackPhase="true" syncCommitPhase="true" transactionMode="TRANSACTIONAL"/>
+      <jmxStatistics enabled="true"/>
+      <eviction strategy="LRU" threadPolicy="DEFAULT" maxEntries="1000000"/>
+      <expiration wakeUpInterval="5000"/>
+   </default>
+</infinispan>

--- a/services/core/src/test/resources/conf/jcr/jbosscache/local/jcr-infinispan-lock-config.xml
+++ b/services/core/src/test/resources/conf/jcr/jbosscache/local/jcr-infinispan-lock-config.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2009 eXo Platform SAS.
+
+    This is free software; you can redistribute it and/or modify it
+    under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation; either version 2.1 of
+    the License, or (at your option) any later version.
+
+    This software is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this software; if not, write to the Free
+    Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+    02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+-->
+<infinispan
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:infinispan:config:5.2 http://www.infinispan.org/schemas/infinispan-config-5.2.xsd"
+  xmlns="urn:infinispan:config:5.2">
+
+    <global>
+      <globalJmxStatistics jmxDomain="exo" enabled="true" allowDuplicateDomains="true"/>
+    </global>
+
+    <default>
+      <locking isolationLevel="READ_COMMITTED" lockAcquisitionTimeout="20000" writeSkewCheck="false" concurrencyLevel="500" useLockStriping="false"/>
+      <transaction transactionManagerLookupClass="org.exoplatform.services.transaction.infinispan.JBossStandaloneJTAManagerLookup" syncRollbackPhase="true" syncCommitPhase="true" transactionMode="TRANSACTIONAL"/>
+      <jmxStatistics enabled="true"/>
+
+      <loaders passivation="false" shared="true" preload="true">
+        <store class="org.exoplatform.services.jcr.infinispan.JdbcStringBasedCacheStore" fetchPersistentState="true" ignoreModifications="false" purgeOnStartup="false">
+          <properties>
+             <property name="stringsTableNamePrefix" value="${infinispan-cl-cache.jdbc.table.name}"/>
+             <property name="idColumnName" value="${infinispan-cl-cache.jdbc.id.column}"/>
+             <property name="dataColumnName" value="${infinispan-cl-cache.jdbc.data.column}"/>
+             <property name="timestampColumnName" value="${infinispan-cl-cache.jdbc.timestamp.column}"/>
+             <property name="idColumnType" value="${infinispan-cl-cache.jdbc.id.type}"/>
+             <property name="dataColumnType" value="${infinispan-cl-cache.jdbc.data.type}"/>
+             <property name="timestampColumnType" value="${infinispan-cl-cache.jdbc.timestamp.type}"/>
+             <property name="dropTableOnExit" value="${infinispan-cl-cache.jdbc.table.drop}"/>
+             <property name="createTableOnStart" value="${infinispan-cl-cache.jdbc.table.create}"/>
+             <property name="connectionFactoryClass" value="${infinispan-cl-cache.jdbc.connectionFactory}"/>
+             <property name="datasourceJndiLocation" value="${infinispan-cl-cache.jdbc.datasource}"/>
+          </properties>
+          <async enabled="false"/>
+        </store>
+      </loaders>
+   </default>
+
+</infinispan>

--- a/services/core/src/test/resources/conf/portal/test-repository-configuration.xml
+++ b/services/core/src/test/resources/conf/portal/test-repository-configuration.xml
@@ -49,13 +49,11 @@
             </properties>
           </initializer>
           <cache enabled="true"
-            class="org.exoplatform.services.jcr.impl.dataflow.persistent.jbosscache.JBossCacheWorkspaceStorageCache">
+                 class="org.exoplatform.services.jcr.impl.dataflow.persistent.infinispan.ISPNCacheWorkspaceStorageCache">
             <properties>
-              <property name="jbosscache-configuration" value="${gatein.jcr.cache.config}" />
+              <property name="infinispan-configuration" value="${gatein.jcr.cache.config}"/>
               <property name="jgroups-configuration" value="${gatein.jcr.jgroups.config}" />
-              <property name="jbosscache-cluster-name" value="jcr-cache${container.name.suffix}" />
-              <property name="jbosscache-shareable" value="true" />
-              <property name="jbosscache-expiration-time" value="${gatein.jcr.cache.expiration.time}" />
+              <property name="infinispan-cluster-name" value="jcr-cache${container.name.suffix}"/>
             </properties>
           </cache>
           <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
@@ -70,21 +68,20 @@
               <property name="max-volatile-time" value="60" />
             </properties>
           </query-handler>
-          <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.jbosscache.CacheableLockManagerImpl">
+          <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.infinispan.ISPNCacheableLockManagerImpl">
             <properties>
               <property name="time-out" value="15m" />
-              <property name="jbosscache-configuration" value="${gatein.jcr.lock.cache.config}" />
+              <property name="infinispan-configuration" value="${gatein.jcr.lock.cache.config}"/>
               <property name="jgroups-configuration" value="${gatein.jcr.jgroups.config}" />
-              <property name="jbosscache-cluster-name" value="jcr-lock${container.name.suffix}" />
-              <property name="jbosscache-shareable" value="true" />
-              <property name="jbosscache-cl-cache.jdbc.table.name" value="jcrlocks" />
-              <property name="jbosscache-cl-cache.jdbc.table.create" value="true" />
-              <property name="jbosscache-cl-cache.jdbc.table.drop" value="false" />
-              <property name="jbosscache-cl-cache.jdbc.table.primarykey" value="pk" />
-              <property name="jbosscache-cl-cache.jdbc.fqn.column" value="fqn" />
-              <property name="jbosscache-cl-cache.jdbc.node.column" value="node" />
-              <property name="jbosscache-cl-cache.jdbc.parent.column" value="parent" />
-              <property name="jbosscache-cl-cache.jdbc.datasource" value="${gatein.jcr.repository.default}" />
+              <property name="infinispan-cluster-name" value="jcr-lock${container.name.suffix}"/>
+              <property name="infinispan-cl-cache.jdbc.table.name" value="jcrlock"/>
+              <property name="infinispan-cl-cache.jdbc.table.create" value="true"/>
+              <property name="infinispan-cl-cache.jdbc.table.drop" value="false"/>
+              <property name="infinispan-cl-cache.jdbc.id.column" value="id" />
+              <property name="infinispan-cl-cache.jdbc.data.column" value="data" />
+              <property name="infinispan-cl-cache.jdbc.timestamp.column" value="timestamp" />
+              <property name="infinispan-cl-cache.jdbc.datasource" value="${gatein.jcr.repository.default}"/>
+              <property name="infinispan-cl-cache.jdbc.connectionFactory" value="org.infinispan.loaders.jdbc.connectionfactory.ManagedConnectionFactory" />
             </properties>
           </lock-manager>
         </workspace>
@@ -110,13 +107,11 @@
             </properties>
           </initializer>
           <cache enabled="true"
-            class="org.exoplatform.services.jcr.impl.dataflow.persistent.jbosscache.JBossCacheWorkspaceStorageCache">
+                 class="org.exoplatform.services.jcr.impl.dataflow.persistent.infinispan.ISPNCacheWorkspaceStorageCache">
             <properties>
-              <property name="jbosscache-configuration" value="${gatein.jcr.cache.config}" />
+              <property name="infinispan-configuration" value="${gatein.jcr.cache.config}"/>
               <property name="jgroups-configuration" value="${gatein.jcr.jgroups.config}" />
-              <property name="jbosscache-cluster-name" value="jcr-cache${container.name.suffix}" />
-              <property name="jbosscache-shareable" value="true" />
-              <property name="jbosscache-expiration-time" value="${gatein.jcr.cache.expiration.time}" />
+              <property name="infinispan-cluster-name" value="jcr-cache${container.name.suffix}"/>
             </properties>
           </cache>
           <query-handler class="org.exoplatform.services.jcr.impl.core.query.lucene.SearchIndex">
@@ -131,21 +126,20 @@
               <property name="max-volatile-time" value="60" />
             </properties>
           </query-handler>
-          <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.jbosscache.CacheableLockManagerImpl">
+          <lock-manager class="org.exoplatform.services.jcr.impl.core.lock.infinispan.ISPNCacheableLockManagerImpl">
             <properties>
               <property name="time-out" value="15m" />
-              <property name="jbosscache-configuration" value="${gatein.jcr.lock.cache.config}" />
+              <property name="infinispan-configuration" value="${gatein.jcr.lock.cache.config}"/>
               <property name="jgroups-configuration" value="${gatein.jcr.jgroups.config}" />
-              <property name="jbosscache-cluster-name" value="jcr-lock${container.name.suffix}" />
-              <property name="jbosscache-shareable" value="true" />
-              <property name="jbosscache-cl-cache.jdbc.table.name" value="jcrlocks" />
-              <property name="jbosscache-cl-cache.jdbc.table.create" value="true" />
-              <property name="jbosscache-cl-cache.jdbc.table.drop" value="false" />
-              <property name="jbosscache-cl-cache.jdbc.table.primarykey" value="pk" />
-              <property name="jbosscache-cl-cache.jdbc.fqn.column" value="fqn" />
-              <property name="jbosscache-cl-cache.jdbc.node.column" value="node" />
-              <property name="jbosscache-cl-cache.jdbc.parent.column" value="parent" />
-              <property name="jbosscache-cl-cache.jdbc.datasource" value="${gatein.jcr.repository.default}" />
+              <property name="infinispan-cluster-name" value="jcr-lock${container.name.suffix}"/>
+              <property name="infinispan-cl-cache.jdbc.table.name" value="jcrlock"/>
+              <property name="infinispan-cl-cache.jdbc.table.create" value="true"/>
+              <property name="infinispan-cl-cache.jdbc.table.drop" value="false"/>
+              <property name="infinispan-cl-cache.jdbc.id.column" value="id" />
+              <property name="infinispan-cl-cache.jdbc.data.column" value="data" />
+              <property name="infinispan-cl-cache.jdbc.timestamp.column" value="timestamp" />
+              <property name="infinispan-cl-cache.jdbc.datasource" value="${gatein.jcr.repository.default}"/>
+              <property name="infinispan-cl-cache.jdbc.connectionFactory" value="org.infinispan.loaders.jdbc.connectionfactory.ManagedConnectionFactory" />
             </properties>
           </lock-manager>
         </workspace>

--- a/services/ecms/pom.xml
+++ b/services/ecms/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-services</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-services-ecms</artifactId>
   <packaging>jar</packaging>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-parent</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-services</artifactId>
   <packaging>pom</packaging>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.addons</groupId>
     <artifactId>exo-clouddrive-parent</artifactId>
-    <version>1.3.x-SNAPSHOT</version>
+    <version>1.3.x-plf43-SNAPSHOT</version>
   </parent>
   <artifactId>exo-clouddrive-webapp</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
On the road to upgrade UXP with platform 4.3, we upgrade exo-cloud with plf 4.3 also and it requires to upgrade cloude-drive-extension. I did it at feature/plf43 branch but I don't have permission on "exo-addons" repository. Please help me to review this one.